### PR TITLE
change festival site link

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -11,7 +11,7 @@ hero:
       link: /sql-injection
       icon: right-arrow
     - text: "ut.code(); 学園祭特設ウェブサイトへ"
-      link: https://kf75.utcode.net
+      link: https://festival.utcode.net
       variant: minimal
       icon: external
 ---


### PR DESCRIPTION
トップページの「ut.code(); 学園祭特設ウェブサイトへ」を
kf75.utcode.net -> festival.utcode.net　に変更